### PR TITLE
Add object match endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,21 @@
 			<artifactId>spring-boot-configuration-processor</artifactId>
  			<version>3.3.4</version>
 		</dependency>
+		<dependency>
+    		<groupId>io.jsonwebtoken</groupId>
+   			<artifactId>jjwt-api</artifactId>
+   			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+		    <groupId>io.jsonwebtoken</groupId>
+		    <artifactId>jjwt-impl</artifactId>
+		    <version>0.11.5</version>
+		</dependency>
+		<dependency>
+		    <groupId>io.jsonwebtoken</groupId>
+		    <artifactId>jjwt-jackson</artifactId>
+		    <version>0.11.5</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/xttribute/object/Object.java
+++ b/src/main/java/com/xttribute/object/Object.java
@@ -9,14 +9,18 @@ public class Object {
 	public String collName;
 	public String docContents;
 	public String uKey;
+	public String operator;
+	public String returnType;
 	
 	public Object() {}
 	
-	public Object(String dbName, String collName, String docContents, String uKey) {
+	public Object(String dbName, String collName, String docContents, String uKey, String operator, String returnType) {
 		this.dbName = dbName;
 		this.collName = collName;
 		this.docContents = docContents;
 		this.uKey = uKey;
+		this.operator = operator;
+		this.returnType = returnType;
 	}
 	
 	public String getDBName() {
@@ -35,4 +39,11 @@ public class Object {
 		return this.uKey;
 	}
 	
+	public String getOperator() {
+		return this.operator;
+	}
+	
+	public String getReturnType() {
+		return this.returnType;
+	}
 }

--- a/src/main/java/com/xttribute/object/controller/JsonController.java
+++ b/src/main/java/com/xttribute/object/controller/JsonController.java
@@ -33,4 +33,5 @@ public class JsonController {
 		String dValue = jContents.getString(key);
 		return dValue;
 	}
+	
 }

--- a/src/main/java/com/xttribute/object/controller/SecurityController.java
+++ b/src/main/java/com/xttribute/object/controller/SecurityController.java
@@ -1,0 +1,19 @@
+package com.xttribute.object.controller;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+
+public class SecurityController {
+	private static final Key SECRET_KEY = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+
+    public static String generateToken(String string) {
+        return Jwts.builder()
+                .setSubject(string)
+                .setIssuedAt(new Date())
+                .signWith(SECRET_KEY)
+                .compact();
+    }
+}

--- a/src/main/java/com/xttribute/object/service/DocumentService.java
+++ b/src/main/java/com/xttribute/object/service/DocumentService.java
@@ -1,20 +1,25 @@
 package com.xttribute.object.service;
 
+import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import javax.swing.text.Document;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.configurationprocessor.json.JSONException;
 import org.springframework.data.mongodb.core.MongoTemplate;
-
+import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.web.servlet.ModelAndView;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.xttribute.object.ApplicationConfiguration;
+import com.xttribute.object.controller.JsonController;
 
 public class DocumentService {
 	ApplicationConfiguration appconfig = new ApplicationConfiguration();
@@ -35,5 +40,27 @@ public class DocumentService {
 		MongoTemplate mTemplate = (MongoTemplate) appconfig.mongoTemplate(mclient, dbName);
 		mTemplate.save(dContents, collName);
 		modelAndView.addObject("doc_201","Document created");
+	}
+	
+	public Map<String, Object> getDocumentByOperator (String dbName, String collName, String dContents, String operator, ModelAndView modelAndView) throws JsonParseException, IOException, JSONException {
+		MongoTemplate mTemplate = (MongoTemplate) appconfig.mongoTemplate(mclient, dbName);
+		List<String> docKeys = JsonController.getJsonKeys(dContents,modelAndView);
+		String q = null;
+		for (int i=0; i< docKeys.size(); i++) {
+			String dValue = JsonController.getJsonValueByKey(dContents, docKeys.get(i), modelAndView);
+			if(i==0) {
+				q = "{ $"+operator+":[{ "+docKeys.get(i)+":'"+dValue+"'},";
+			}else {
+				q +="{"+docKeys.get(i)+":'"+dValue+"'}";
+			}			
+		}
+		q += "]}";
+		BasicQuery query =new BasicQuery(q);
+		if(mTemplate.findOne(query, Map.class, collName)!= null) {
+			modelAndView.addObject("doc_302","Document matched");
+		}else {
+			modelAndView.addObject("doc_204","No document matched");
+		}
+		return mTemplate.findOne(query, Map.class, collName);
 	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=object
+security.basic.enabled=false
+management.security.enabled=false


### PR DESCRIPTION
match will take each parameter in document contents and use operator to match the records. it will also take return type to use case define what needs to be returned. token: generate a token if records matched : this can be mainly used for application want to have a token to control the login

matchObject is not used to get document, and it will take the return type as long as there is one match under the condition.